### PR TITLE
Eliminating module suffixes.

### DIFF
--- a/cmake/FindGFTL_SHARED.cmake
+++ b/cmake/FindGFTL_SHARED.cmake
@@ -31,6 +31,9 @@ else()
     INSTALL_COMMAND make install)
 
   ExternalProject_Add_StepDependencies(gFTL-shared configure gFTL)
+  add_library(lib_libgFTL-shared STATIC IMPORTED)
+  message("Huh: ${gFTL-shared_install_dir} ${gFTL-shared_install_dir}")
+  set_target_properties(lib_libgFTL-shared PROPERTIES IMPORTED_LOCATION ${gFTL-shared_install_dir}/lib/libgFTL-shared.a)
 
 
 endif()

--- a/src/AbstractArgParser.F90
+++ b/src/AbstractArgParser.F90
@@ -11,7 +11,7 @@
 
 
 
-module fp_AbstractArgParser_mod
+module fp_AbstractArgParser
    implicit none
    private
    
@@ -40,7 +40,7 @@ module fp_AbstractArgParser_mod
       end subroutine print_help
 
       subroutine act(this, namespace, parser, value, option_string)
-         use gFTL_StringUnlimitedMapMod
+         use gFTL_StringUnlimitedMap
          import AbstractAction
          import AbstractArgParser
          class (AbstractAction), intent(inout) :: this
@@ -52,4 +52,4 @@ module fp_AbstractArgParser_mod
       
    end interface
 
-end module fp_AbstractArgParser_mod
+end module fp_AbstractArgParser

--- a/src/ActionVector.F90
+++ b/src/ActionVector.F90
@@ -1,8 +1,8 @@
-module fp_ActionVector_mod
-   use fp_BaseAction_mod
+module fp_ActionVector
+   use fp_BaseAction
 #define _vector ActionVector
 #define _iterator ActionVectorIterator
 #define _type class(BaseAction)
 #define _allocatable
 #include "templates/vector.inc"
-end module fp_ActionVector_mod
+end module fp_ActionVector

--- a/src/ArgParser.F90
+++ b/src/ArgParser.F90
@@ -8,20 +8,20 @@
 !----------------------------------------------------------------------------
 
 #include "unused_dummy.fh"
-module fp_ArgParser_mod
-   use fp_BaseAction_mod
-   use fp_ActionVector_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
-   use fp_StoreAction_mod
-   use fp_ActionVector_mod
-   use fp_StringActionMap_mod
-   use fp_KeywordEnforcer_mod
-   use fp_None_mod
-   use gFTL_IntegerVectorMod
-   use gFTL_RealVectorMod
-   use gFTL_StringVectorMod
-   use gFTL_StringUnlimitedMapMod
+module fp_ArgParser
+   use fp_BaseAction
+   use fp_ActionVector
+   use fp_AbstractArgParser
+   use fp_BaseAction
+   use fp_StoreAction
+   use fp_ActionVector
+   use fp_StringActionMap
+   use fp_KeywordEnforcer
+   use fp_None
+   use gFTL_IntegerVector
+   use gFTL_RealVector
+   use gFTL_StringVector
+   use gFTL_StringUnlimitedMap
    implicit none
    private
 
@@ -68,7 +68,7 @@ contains
 
 
    function new_argParser_empty(program_name) result(parser)
-      use fp_CommandLineArguments_mod
+      use fp_CommandLineArguments
       type (ArgParser) :: parser
       character(*), optional, intent(in) :: program_name
 
@@ -86,11 +86,11 @@ contains
    end function new_argParser_empty
 
    subroutine initialize_registry(this)
-      use fp_HelpAction_mod
-      use fp_StoreAction_mod
-      use fp_StoreConstAction_mod
-      use fp_StoreTrueAction_mod
-      use fp_StoreFalseAction_mod
+      use fp_HelpAction
+      use fp_StoreAction
+      use fp_StoreConstAction
+      use fp_StoreTrueAction
+      use fp_StoreFalseAction
       class (ArgParser), intent(inout) :: this
 
       type (HelpAction) :: help_action
@@ -168,7 +168,7 @@ contains
 
 
    function parse_args_command_line(this, unused, unprocessed) result(option_values)
-     use fp_CommandLineArguments_mod
+     use fp_CommandLineArguments
       type (StringUnlimitedMap) :: option_values
       class (ArgParser), intent(in) :: this
       class (KeywordEnforcer), optional, intent(in) :: unused
@@ -586,4 +586,4 @@ contains
 
    end subroutine add_action
 
-end module fp_ArgParser_mod
+end module fp_ArgParser

--- a/src/BaseAction.F90
+++ b/src/BaseAction.F90
@@ -1,9 +1,9 @@
 #include "unused_dummy.fh"
-module fp_BaseAction_mod
-   use fp_AbstractArgParser_mod, only: AbstractAction
-   use fp_KeywordEnforcer_mod
-   use gFTL_StringVectorMod
-   use fp_None_mod
+module fp_BaseAction
+   use fp_AbstractArgParser, only: AbstractAction
+   use fp_KeywordEnforcer
+   use gFTL_StringVector
+   use fp_None
    implicit none
    private
 
@@ -255,8 +255,8 @@ contains
 
 
    subroutine act(this, namespace, parser, value, option_string)
-      use fp_AbstractArgParser_mod, only: AbstractArgParser
-      use gFTL_stringUnlimitedMapMod
+      use fp_AbstractArgParser, only: AbstractArgParser
+      use gFTL_stringUnlimitedMap
       class (BaseAction), intent(inout) :: this
       type (StringUnlimitedMap), intent(inout) :: namespace
       class (AbstractArgParser), intent(in) :: parser
@@ -297,4 +297,4 @@ contains
 
 
 
-end module fp_BaseAction_mod
+end module fp_BaseAction

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ message("two ${gFTL-shared_install_dir}/include")
 
 
 add_library(fargparse STATIC ${srcs})
-target_link_libraries(fargparse ${gFTL_shared_install_dir}/lib/libgFTL-shared.a)
+target_link_libraries(fargparse ${gFTL-shared_install_dir}/lib/libgFTL-shared.a)
 
 if (NOT GFTL)
   add_dependencies(fargparse gFTL)

--- a/src/Cast.F90
+++ b/src/Cast.F90
@@ -1,5 +1,5 @@
-module fp_Cast_mod
-   use fp_ErrorCodes_mod
+module fp_Cast
+   use fp_ErrorCodes
    implicit none
    private
 
@@ -102,7 +102,7 @@ contains
    end subroutine cast_to_real
 
    subroutine cast_to_integer_vector(unlimited, v, rc)
-     use gFTL_IntegerVectorMod
+     use gFTL_IntegerVector
       class(*), intent(in) :: unlimited
       type(IntegerVector), intent(out) :: v
       integer, optional, intent(out) :: rc
@@ -123,7 +123,7 @@ contains
 
    
    subroutine cast_to_real_vector(unlimited, v, rc)
-     use gFTL_RealVectorMod
+     use gFTL_RealVector
       class(*), intent(in) :: unlimited
       type(RealVector), intent(out) :: v
       integer, optional, intent(out) :: rc
@@ -144,7 +144,7 @@ contains
 
    
    subroutine cast_to_string_vector(unlimited, v, rc)
-     use gFTL_StringVectorMod
+     use gFTL_StringVector
       class(*), intent(in) :: unlimited
       type(StringVector), intent(out) :: v
       integer, optional, intent(out) :: rc
@@ -164,4 +164,4 @@ contains
     end subroutine cast_to_string_vector
 
    
-end module fp_Cast_mod
+end module fp_Cast

--- a/src/CommandLineArguments.F90
+++ b/src/CommandLineArguments.F90
@@ -1,5 +1,5 @@
-module fp_CommandLineArguments_mod
-   use gFTL_StringVectorMod
+module fp_CommandLineArguments
+   use gFTL_StringVector
    implicit none
 
    private
@@ -35,4 +35,4 @@ contains
    end function get_command_line_arguments
 
 
-end module fp_CommandLineArguments_mod
+end module fp_CommandLineArguments

--- a/src/ErrorCodes.F90
+++ b/src/ErrorCodes.F90
@@ -1,4 +1,4 @@
-module fp_ErrorCodes_mod
+module fp_ErrorCodes
    implicit none
    public
 
@@ -8,4 +8,4 @@ module fp_ErrorCodes_mod
       enumerator :: UNKNOWN_ACTION
    end enum
 
-end module fp_ErrorCodes_mod
+end module fp_ErrorCodes

--- a/src/HelpAction.F90
+++ b/src/HelpAction.F90
@@ -1,9 +1,9 @@
 #include "unused_dummy.fh"
-module fp_HelpAction_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
-   use fp_KeywordEnforcer_mod
-   use fp_None_mod
+module fp_HelpAction
+   use fp_AbstractArgParser
+   use fp_BaseAction
+   use fp_KeywordEnforcer
+   use fp_None
    implicit none
    private
 
@@ -51,7 +51,7 @@ contains
 
 
    subroutine act(this, namespace, parser, value, option_string)
-      use gFTL_StringUnlimitedMapMod
+      use gFTL_StringUnlimitedMap
       class (HelpAction), intent(inout) :: this
       type (StringUnlimitedMap), intent(inout) :: namespace
       class (AbstractArgParser), intent(in) :: parser
@@ -68,4 +68,4 @@ contains
 
    end subroutine act
 
-end module fp_HelpAction_mod
+end module fp_HelpAction

--- a/src/KeywordEnforcer.F90
+++ b/src/KeywordEnforcer.F90
@@ -21,7 +21,7 @@
 ! ABSTRACT extensions can be created, but do not circumvent the
 ! keyword enforcement.
 
-module fp_KeywordEnforcer_mod
+module fp_KeywordEnforcer
    implicit none
    private
 
@@ -37,4 +37,4 @@ module fp_KeywordEnforcer_mod
       end subroutine nonimplementable
    end interface
 
-end module fp_KeywordEnforcer_mod
+end module fp_KeywordEnforcer

--- a/src/None.F90
+++ b/src/None.F90
@@ -1,4 +1,4 @@
-module fp_None_mod
+module fp_None
    implicit none
    private
 
@@ -28,4 +28,4 @@ module fp_None_mod
         
    end function equal_equal
    
-end module fp_None_mod
+end module fp_None

--- a/src/StoreAction.F90
+++ b/src/StoreAction.F90
@@ -1,6 +1,6 @@
-module fp_StoreAction_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
+module fp_StoreAction
+   use fp_AbstractArgParser
+   use fp_BaseAction
    implicit none
    private
 
@@ -14,7 +14,7 @@ module fp_StoreAction_mod
 contains
 
    subroutine act(this, namespace, parser, value, option_string)
-      use gFTL_StringUnlimitedMapMod
+      use gFTL_StringUnlimitedMap
       class (StoreAction), intent(inout) :: this
       type (StringUnlimitedMap), intent(inout) :: namespace
       class (AbstractArgParser), intent(in) :: parser
@@ -25,4 +25,4 @@ contains
 
    end subroutine act
 
-end module fp_StoreAction_mod
+end module fp_StoreAction

--- a/src/StoreConstAction.F90
+++ b/src/StoreConstAction.F90
@@ -1,9 +1,9 @@
 #include "unused_dummy.fh"
-module fp_StoreConstAction_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
-   use fp_KeywordEnforcer_mod
-   use fp_None_mod
+module fp_StoreConstAction
+   use fp_AbstractArgParser
+   use fp_BaseAction
+   use fp_KeywordEnforcer
+   use fp_None
    implicit none
    private
 
@@ -60,7 +60,7 @@ contains
 
 
    subroutine act(this, namespace, parser, value, option_string)
-      use gFTL_StringUnlimitedMapMod
+      use gFTL_StringUnlimitedMap
       class (StoreConstAction), intent(inout) :: this
       type (StringUnlimitedMap), intent(inout) :: namespace
       class (AbstractArgParser), intent(in) :: parser
@@ -71,4 +71,4 @@ contains
 
    end subroutine act
 
-end module fp_StoreConstAction_mod
+end module fp_StoreConstAction

--- a/src/StoreFalseAction.F90
+++ b/src/StoreFalseAction.F90
@@ -1,10 +1,10 @@
 #include "unused_dummy.fh"
 
-module fp_StoreFalseAction_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
-   use fp_StoreConstAction_mod
-   use fp_KeywordEnforcer_mod
+module fp_StoreFalseAction
+   use fp_AbstractArgParser
+   use fp_BaseAction
+   use fp_StoreConstAction
+   use fp_KeywordEnforcer
    implicit none
    private
 
@@ -55,4 +55,4 @@ contains
 
    end subroutine initialize
 
-end module fp_StoreFalseAction_mod
+end module fp_StoreFalseAction

--- a/src/StoreTrueAction.F90
+++ b/src/StoreTrueAction.F90
@@ -1,10 +1,10 @@
 #include "unused_dummy.fh"
 
-module fp_StoreTrueAction_mod
-   use fp_AbstractArgParser_mod
-   use fp_BaseAction_mod
-   use fp_StoreConstAction_mod
-   use fp_KeywordEnforcer_mod
+module fp_StoreTrueAction
+   use fp_AbstractArgParser
+   use fp_BaseAction
+   use fp_StoreConstAction
+   use fp_KeywordEnforcer
    implicit none
    private
 
@@ -54,4 +54,4 @@ contains
            & type=type, dest=dest, default=default_, const=.true., help=help)
    end subroutine initialize
 
-end module fp_StoreTrueAction_mod
+end module fp_StoreTrueAction

--- a/src/StringActionMap.F90
+++ b/src/StringActionMap.F90
@@ -1,5 +1,5 @@
-module fp_StringActionMap_mod
-   use fp_BaseAction_mod
+module fp_StringActionMap
+   use fp_BaseAction
 #define _map StringActionMap
 #define _iterator StringActionMapIterator
 #include "types/key_deferredLengthString.inc"
@@ -7,4 +7,4 @@ module fp_StringActionMap_mod
 #define _value_allocatable
 #define _alt
 #include "templates/map.inc"
-end module fp_StringActionMap_mod
+end module fp_StringActionMap

--- a/src/fParse.F90
+++ b/src/fParse.F90
@@ -1,11 +1,11 @@
 module fParse
-   use fp_ArgParser_mod
-   use fP_CommandLineArguments_mod
-   use fp_Cast_mod
-   use gFTL_StringUnlimitedMapMod
-   use gFTL_StringVectorMod
-   use gFTL_IntegerVectorMod
-   use gFTL_RealVectorMod
+   use fp_ArgParser
+   use fP_CommandLineArguments
+   use fp_Cast
+   use gFTL_StringUnlimitedMap
+   use gFTL_StringVector
+   use gFTL_IntegerVector
+   use gFTL_RealVector
    implicit none
 
    public :: ArgParser

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mod)
 include_directories(${PFUNIT}/mod)
 include_directories(${fArgParse_BINARY_DIR}/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${gftl_shared_install_dir}/mod)
+include_directories(${gFTL-shared_install_dir}/mod)
 
 add_library(fargparse_tests EXCLUDE_FROM_ALL ${test_srcs})
 target_link_libraries(fargparse_tests fargparse ${PFUNIT}/lib/libpfunit.a)

--- a/tests/Test_ArgParser.pf
+++ b/tests/Test_ArgParser.pf
@@ -1,12 +1,12 @@
-module Test_ArgParser_mod
+module Test_ArgParser
    use pFUnit_mod
-   use fp_ArgParser_mod
-   use fp_Cast_mod
-   use fp_ErrorCodes_mod
-   use gFTL_StringVectorMod
-   use gFTL_StringUnlimitedMapMod
-   use gFTL_IntegerVectorMod
-   use gFTL_RealVectorMod
+   use fp_ArgParser
+   use fp_Cast
+   use fp_ErrorCodes
+   use gFTL_StringVector
+   use gFTL_StringUnlimitedMap
+   use gFTL_IntegerVector
+   use gFTL_RealVector
    implicit none
 
    @suite(name='ArgParser_suite')
@@ -534,4 +534,4 @@ contains
     end subroutine test_nargs_is_asterisk_2_arg
 
 
-end module Test_ArgParser_mod
+end module Test_ArgParser

--- a/tests/Test_BaseAction.pf
+++ b/tests/Test_BaseAction.pf
@@ -1,5 +1,5 @@
-module Test_BaseAction_mod
-   use fp_BaseAction_mod
+module Test_BaseAction
+   use fp_BaseAction
    use pFUnit_mod
    implicit none
 
@@ -59,4 +59,4 @@ contains
    end subroutine test_get_destination
 
 
-end module Test_BaseAction_mod
+end module Test_BaseAction

--- a/tests/Test_Cast.pf
+++ b/tests/Test_Cast.pf
@@ -1,7 +1,7 @@
-module Test_Cast_mod
+module Test_Cast
    use pFUnit_mod
-   use fp_Cast_mod
-   use fp_ErrorCodes_mod
+   use fp_Cast
+   use fp_ErrorCodes
    implicit none
 
    @suite(name='Cast_suite')
@@ -144,4 +144,4 @@ contains
    end subroutine test_cast_to_real_fail
 
 
-end module Test_Cast_mod
+end module Test_Cast


### PR DESCRIPTION
Module suffixes are annoyingly inconsistent across projects/orgs.   We
do not use suffixes to distinguish other program units (SUBROUTINE,
FUNCTION, PROGRAM), so why is MODULE any different?

Note, that it remains necessary to have module names differ from the
derived types that are declared within them.   But project-specific
prefixes are preferred, as they also serve the purpose of reducing
issues with namespace conflicts.