### PR TITLE
Fixes #52 - updates to work with pFUnit-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,107 @@
+sudo: false
+dist: xenial
+language: c
+
+matrix:
+   include:
+      - os: linux
+        addons:
+           apt:
+              sources:
+                 - ubuntu-toolchain-r-test
+              packages:
+                 - gfortran-7
+                 - cmake
+        env:
+           - FC='gfortran-7'
+      - os: linux
+        addons:
+           apt:
+              sources:
+                 - ubuntu-toolchain-r-test
+              packages:
+                 - gfortran-8
+                 - cmake
+        env:
+           - FC='gfortran-8'
+      - os: linux
+        addons:
+           apt:
+              sources:
+                 - ubuntu-toolchain-r-test
+              packages:
+                 - gfortran-9
+                 - cmake
+        env:
+           - FC='gfortran-9'
+      - os: osx
+        env: FC='gfortran-7' BREW='gcc@7' BREW_UP='cmake'
+      - os: osx
+        env: FC='gfortran-8' BREW='gcc@8' BREW_UP='cmake'
+      - os: osx
+        env: FC='gfortran-9' BREW='gcc@9' BREW_UP='cmake'
+
+before_install:
+   - |
+      if [ $TRAVIS_OS_NAME == osx ] ; then
+         brew install ${BREW} make || exit 1
+         brew upgrade ${BREW_UP} || exit 1
+      fi
+
+install:
+  # Set the ${CXX} variable properly
+#  - export CXX=${COMPILER}
+#  - ${CXX} --version
+
+  # Dependencies required by the CI are installed in ${TRAVIS_BUILD_DIR}/deps/
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - mkdir -p "${DEPS_DIR}"
+  - cd "${DEPS_DIR}"
+
+  # Travis machines have 2 cores
+  - JOBS=2
+
+  ############################################################################
+  # Install a recent CMake (unless already installed on OS X)
+  ############################################################################
+  - CMAKE_VERSION=3.14.5
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      mkdir cmake && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+  - cmake --version
+
+before_script:
+   # First get pFUnit
+   - cd ${HOME}
+   - git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+
+   # Now build pFUnit
+   - cd ${HOME}/pFUnit
+   - mkdir build-serial
+   - cd build-serial
+   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=$HOME/Software/pFUnit -DSKIP_MPI=YES -DSKIP_OPENMP=YES
+   - make -j4 install
+
+   # Now build fArgParse
+   - cd ${TRAVIS_BUILD_DIR}
+   - mkdir build
+   - cd build
+   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=$HOME/Software/fArgParse -DCMAKE_PREFIX_PATH=$HOME/Software/pFUnit -DCMAKE_BUILD_TYPE=Debug
+
+script:
+   # Build and install
+   - make -j install
+   # Test
+   - make -j tests
+
+notifications:
+   email:
+      recipients:
+         - matthew.thompson@nasa.gov
+         - thomas.l.clune@nasa.gov
+         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,23 +18,30 @@ if(NOT found)
   message( FATAL_ERROR "Unrecognized Fortran compiler. Please use ifort, gfortran, NAG, PGI, or XL.")
 endif()
 
-# Need pFUnit if want to build tests
-set(PFUNIT "" CACHE PATH "(optional) path to installed testing framework")
-
 add_subdirectory(extern)
 add_subdirectory (src)
-
-if (PFUNIT)
-  if (NOT TARGET tests)
-    enable_testing()
-    add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND})
-  endif ()
-  add_subdirectory (tests)
-endif ()
 
 if (examples)
   add_subdirectory(Examples)
 endif()
+
+find_package (PFUNIT 4.0.1 QUIET)
+if (PFUNIT_FOUND)
+  project (GFTL-TEST
+    VERSION ${GFTL_VERSION}
+    LANGUAGES Fortran
+    )
+
+  set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${GFTL_SOURCE_DIR}/cmake_utils")
+  include (${CMAKE_Fortran_COMPILER_ID} RESULT_VARIABLE found)
+
+  enable_testing()
+  if (NOT TARGET (tests))
+    add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND})
+  endif ()
+  
+  add_subdirectory(tests)
+endif ()
 
 # find_package() support
 configure_file (FARGPARSEConfig-version.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/FARGPARSEConfig-version.cmake @ONLY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,35 +4,16 @@ set(pf_tests
   Test_ArgParser.pf
   )
 
-set(test_srcs)
-foreach (file ${pf_tests})
-  get_filename_component(basename ${file} NAME_WE)
-  set(f90_src ${basename}.F90)
-  add_custom_command (
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
-    COMMAND python
-    ARGS ${PFUNIT}/bin/pFUnitParser.py ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${file}
-    )
-  list(APPEND test_srcs ${f90_src})
-endforeach()
+add_pfunit_ctest (fargparse_tests
+  TEST_SOURCES ${pf_tests}
+  LINK_LIBRARIES fargparse
+  )
 
+add_dependencies (tests fargparse_tests)
 
-include_directories(${CMAKE_BINARY_DIR}/src/mod)
-include_directories(${PFUNIT}/mod)
-include_directories(${fArgParse_BINARY_DIR}/src)
+include_directories(${PFUNIT_TOP_DIR}/include)
+include_directories(${FARGPARSE_BINARY_DIR}/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(fargparse_tests EXCLUDE_FROM_ALL ${test_srcs})
-target_link_libraries(fargparse_tests fargparse ${PFUNIT}/lib/libpfunit.a)
-add_executable (test_fargparse.x EXCLUDE_FROM_ALL ${PFUNIT}/include/driver.F90)
-target_link_libraries(test_fargparse.x fargparse_tests)
-
-add_dependencies(tests test_fargparse.x)
-add_test(NAME fargparse_tests
-  COMMAND test_fargparse.x
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
 
 

--- a/tests/Test_ArgParser.pf
+++ b/tests/Test_ArgParser.pf
@@ -1,5 +1,5 @@
 module Test_ArgParser
-   use pFUnit_mod
+   use funit
    use fp_ArgParser
    use fp_Cast
    use fp_ErrorCodes
@@ -9,7 +9,7 @@ module Test_ArgParser
    use gFTL_RealVector
    implicit none
 
-   @suite(name='ArgParser_suite')
+!   @suite(name='ArgParser_suite')
 
 
 

--- a/tests/Test_BaseAction.pf
+++ b/tests/Test_BaseAction.pf
@@ -1,9 +1,9 @@
 module Test_BaseAction
    use fp_BaseAction
-   use pFUnit_mod
+   use funit
    implicit none
 
-   @suite(name='BaseAction_suite')
+!   @suite(name='BaseAction_suite')
 
 contains
 

--- a/tests/Test_Cast.pf
+++ b/tests/Test_Cast.pf
@@ -1,10 +1,10 @@
 module Test_Cast
-   use pFUnit_mod
+   use funit
    use fp_Cast
    use fp_ErrorCodes
    implicit none
 
-   @suite(name='Cast_suite')
+!   @suite(name='Cast_suite')
 
 contains
 


### PR DESCRIPTION
Something more complex is probably needed if/when fArgParse actually
needs to be modified. Things work now because the pre-built
pFUnit is using the same version of fArgParse that is being tested.

- Also added Travis support.   (Needs to be activated separately in the repo though.)