### PR TITLE
Rename pair type within StringActionMap to have type-specific name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 project (FARGPARSE
-  VERSION 0.9.1
+  VERSION 0.9.4
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,31 @@
-0.9.0 2019-09-04
-      - Updated to use pFUnit 4.0
-     
-0.9.1 2019-11-08
-      - Workaround for compiler hang in ifort 19.0.3
-      - Updated gFTL for memory leak workaround in ifort 18
+# Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+
+## [0.9.4] 2020-05-05
+
+### Changed
+- Modified defalut name for Pair in Map container
+  (Workaround for XLF bug.)
+- Updated gFTL/gFTL-shared  
+	
+
+## [0.9.2] 2020-05-05
+
+### Fixed
+- bug with extra arguments
+
+
+## [0.9.1] 2019-11-08
+- Workaround for compiler hang in ifort 19.0.3
+- Updated gFTL for memory leak workaround in ifort 18
+
+## [0.9.0] 2019-09-04
+- Updated to use pFUnit 4.0
+     

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Real documentation is sorely needed here.
  ...
  
  parser = ArgParser()
- call parser%add_argument('-d', '--debug', '--verbose', action='store_true', &
+ call parser%add_argument('-d', '-v', '--debug', '--verbose', action='store_true', &
       & help='make output more verbose')
 
  call parser%add_argument('-f', '--filter', action='store', &

--- a/src/StringActionMap.F90
+++ b/src/StringActionMap.F90
@@ -2,6 +2,7 @@ module fp_StringActionMap
    use fp_BaseAction
 #define _map StringActionMap
 #define _iterator StringActionMapIterator
+#define _pair StringActionMapPair
 #include "types/key_deferredLengthString.inc"
 #define _value class(BaseAction)
 #define _value_allocatable

--- a/src/StringActionMap.F90
+++ b/src/StringActionMap.F90
@@ -2,7 +2,7 @@ module fp_StringActionMap
    use fp_BaseAction
 #define _map StringActionMap
 #define _iterator StringActionMapIterator
-#define _pair StringActionMapPair
+#define _pair StringActionPair
 #include "types/key_deferredLengthString.inc"
 #define _value class(BaseAction)
 #define _value_allocatable


### PR DESCRIPTION
This PR adds the specific typename StringActionMapPair for the pair type contained within the StringActionMap type.  It is analogous to what is already done for the iterator type.  The corresponding changes to gFTL-shared types are made in Goddard-Fortran-Ecosystem/gFTL-shared#21.

This fixes a compile issue for pFUnit under the XLF compiler (see Goddard-Fortran-Ecosystem/pFUnit#208).  It has been tested under Intel and GNU compilers.