### PR TITLE
Ability to use GFE libraries as subprojects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Build Tests
         run: |
           cd build
+          cmake . -DBUILD_TESTING=TRUE
           make -j$(nproc) tests
       - name: Run Tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ if (examples)
   add_subdirectory(Examples)
 endif()
 
-find_package (PFUNIT 4.0.1 QUIET)
-if (PFUNIT_FOUND)
+if (BUILD_TESTING)
+  find_package (PFUNIT 4.0.1 REQUIRED)
   project (FARGPARSE_-TEST
     VERSION ${FARGPARSE_VERSION}
     LANGUAGES Fortran

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Automatic build of the gFTL-shared submodule now happens if
+  GFTL_SHARED::gftl-shared isn't already defined.
+- Build setting BUILD_TESTING must be turned on to build fArgParse unit tests.
+
 ## [1.1.0] 2021-02-06
 
 ### Added

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,9 +33,10 @@ target_include_directories (fargparse PUBLIC
 target_include_directories (fargparse PRIVATE ${FARGPARSE_SOURCE_DIR}/include)
 add_library(FARGPARSE::fargparse ALIAS fargparse)
 
-include(build_submodule)
-build_submodule(../extern/gFTL-shared PROJECT GFTL_SHARED TARGET GFTL_SHARED::gftl-shared)
-
+if (NOT TARGET GFTL_SHARED::gftl-shared)
+  include(build_submodule)
+  build_submodule(../extern/gFTL-shared PROJECT GFTL_SHARED TARGET GFTL_SHARED::gftl-shared)
+endif ()
 if (NOT TARGET GFTL::gftl)
    message(FATAL_ERROR "Could not find gFTL. This should not happen.")
 endif ()


### PR DESCRIPTION
Hi all,

I'm working on revising the GCHP build system to utilize MAPL/GFE build system updates over the past year (on the topic of "seamless" integration for the AIST project).

This PR enables the ability to use GFE libraries as side-by-side subprojects in a superproject. The motivation is to minimize the number of external software dependencies in GCHP for the sake of end-users. It is also useful for creating a single fixture for the GFE libraries, which we can work independently and have an independent CI for. 

Here is a simple demo of the GFE libraries as a single fixture: https://github.com/LiamBindle/GFE-SDK  (happy to transfer to @Goddard-Fortran-Ecosystem if you want it).

## How to merge
This PR can be merged on it's own (no dependencies/dependents).

I have a similar PR for gFTL, gFTL-shared, pFUnit, yaFyaml, and pFlogger too. I figured I would submit this one for discussion (it's representative of the others) and follow up afterwards with the others. 

## Testing
- [X] Compiling fArgParse on its own
- [X] Unit tests pass (note: `BUILD_TESTING` must be turned on to build tests)
- [X] Compiling as a part of GFE-SDK

## Summary of changes
1. `build_submodule()` for gFTL-shared is run if the `GFTL_SHARED::gftl-shared` target is not already defined. This means fArgParse and gFTL-shared can be built side-by-side in a superproject.
2. Use the `BUILD_TESTING` option to control whether tests are built (standard variable for CTest: https://cmake.org/cmake/help/latest/module/CTest.html)
3. If tests are to be built, pFUnit is a require dependency.


Let me know what you think
-Liam