### PR TITLE
Update NVHPC Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `NVHPC.cmake` file for NVHPC support
+
 ## [1.1.1] 2021-11-15
 
 ### Fixed

--- a/cmake/NVHPC.cmake
+++ b/cmake/NVHPC.cmake
@@ -1,8 +1,9 @@
-# Compiler specific flags for PGI Fortran compiler
+# Compiler specific flags for NVHPC Fortran compiler
 
-set(CMAKE_Fortran_FLAGS_DEBUG  "-g -O0")
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-set(CMAKE_Fortran_FLAGS "-g -O0")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
 
-#add_definitions(-D_INTEL)
-#add_definitions(-D__ifort_18)

--- a/cmake/PGI.cmake
+++ b/cmake/PGI.cmake
@@ -1,8 +1,9 @@
 # Compiler specific flags for PGI Fortran compiler
 
-set(CMAKE_Fortran_FLAGS_DEBUG  "-g -O0")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-set(CMAKE_Fortran_FLAGS "-g -O0")
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
 
-#add_definitions(-D_INTEL)
-#add_definitions(-D__ifort_18)
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+


### PR DESCRIPTION
This PR updates the `NVHPC.cmake` file to be identical to that used in pFUnit