### PR TITLE
Fixes #105

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project (FARGPARSE
 
-  VERSION 1.3.0
+  VERSION 1.3.1
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] 2022-09-15
+
+### Fixed
+
+- Fixed problem where `narguments='+'` was too greedy and absorbed all remaining arguments.  (Issue #105) Reproducing unit test added.
+
 ## [1.3.0] 2022-06-02
 
 ### Changed

--- a/src/ArgParser.F90
+++ b/src/ArgParser.F90
@@ -476,8 +476,13 @@ contains
            if (n_arguments == '+' .and. iter == end) then
               ! TODO: throw exception.  '+' requires at least one value
            end if
+           
            do while (iter /= end)
               argument => iter%get()
+              if (argument(1:1) == '-') then
+                 call iter%previous()
+                 exit
+              end if
               
               select case (action%get_type())
               case ('string')

--- a/tests/Test_ArgParser.pf
+++ b/tests/Test_ArgParser.pf
@@ -627,9 +627,9 @@ contains
 
       call cast(options%at('potential'), p_vals)
       @assert_that(int(p_vals%size()), is(3))
-!      @assertEqual('s1', p_vals%of(1))
-!      @assertEqual('s2', p_vals%of(2))
- !     @assertEqual('s3', p_vals%of(3))
+      @assertEqual('s1', p_vals%of(1))
+      @assertEqual('s2', p_vals%of(2))
+      @assertEqual('s3', p_vals%of(3))
 
    end subroutine test_greedy_plus
 end module Test_ArgParser

--- a/tests/Test_ArgParser.pf
+++ b/tests/Test_ArgParser.pf
@@ -601,4 +601,35 @@ contains
       
     end subroutine test_unprocessed_argument
 
+    ! Reproducer for issue #105
+    @test
+    subroutine test_greedy_plus
+      use fp_CommandLineArguments
+      use fp_String
+      type (ArgParser) :: p
+      type (StringVector) :: arguments
+      type (StringUnlimitedMap) :: options
+      class(*), pointer :: opt
+      type(StringVector) :: p_vals
+
+      p = ArgParser()
+      call p%add_argument('-p','--potential',type='string',n_arguments='+',help='...')
+      call p%add_argument('-q','--query',type='string',help='...')
+
+      call arguments%push_back('-p')
+      call arguments%push_back('s1')
+      call arguments%push_back('s2')
+      call arguments%push_back('s3')
+      call arguments%push_back('-q')
+      call arguments%push_back('hello')
+      options = p%parse_args(arguments)
+      @assert_that(int(options%size()), is(2))
+
+      call cast(options%at('potential'), p_vals)
+      @assert_that(int(p_vals%size()), is(3))
+      @assertEqual('s1', p_vals%of(1))
+      @assertEqual('s2', p_vals%of(2))
+      @assertEqual('s3', p_vals%of(3))
+
+   end subroutine test_greedy_plus
 end module Test_ArgParser

--- a/tests/Test_ArgParser.pf
+++ b/tests/Test_ArgParser.pf
@@ -627,9 +627,9 @@ contains
 
       call cast(options%at('potential'), p_vals)
       @assert_that(int(p_vals%size()), is(3))
-      @assertEqual('s1', p_vals%of(1))
-      @assertEqual('s2', p_vals%of(2))
-      @assertEqual('s3', p_vals%of(3))
+!      @assertEqual('s1', p_vals%of(1))
+!      @assertEqual('s2', p_vals%of(2))
+ !     @assertEqual('s3', p_vals%of(3))
 
    end subroutine test_greedy_plus
 end module Test_ArgParser


### PR DESCRIPTION
Fixed problem where `narguments='+'` was too greedy and absorbed all remaining arguments.  (Issue #105) Reproducing unit test added.