### PR TITLE
Handmerge main into develop 2022-Aug-15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project (FARGPARSE
 
-  VERSION 1.2.0
+  VERSION 1.3.0
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Added gfortran-11
    - Added gfortran-12 (for ubuntu-22.04)
 
+## [1.3.0] 2022-06-02
+
+### Changed
+
+- Updated gFTL-shared submodule version
+
 ## [1.2.0] 2022-03-15
 
 ### Added


### PR DESCRIPTION
Due to conflicts, we need to handmerge `main` into `develop`. This supersedes #109 