### PR TITLE
CI: Remove macos-11, add macos-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-22.04, macos-12, macos-13]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
-          - os: macos-11
-            compiler: gfortran-13
           - os: macos-12
+            compiler: gfortran-10
+          - os: macos-13
             compiler: gfortran-10
 
       # fail-fast if set to 'true' here is good for production, but when

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `-quiet` flag for NAG Fortran
+- Remove `macos-11` from GitHub Actions, add `macos-12`
 
 ## [1.7.0] - 2024-03-04
 


### PR DESCRIPTION
As `macos-11` is deprecated at GitHub Actions (and is ancient) we remove it and add `macos-13`