### PR TITLE
Preliminary LLVMFlang Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `-quiet` flag for NAG Fortran
 
+### Added
+
+- LLVMFlang compiler support
+
 ## [1.7.0] - 2024-03-04
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- support for llvm flang
+- LLVMFlang compiler support
 
 ## [1.8.0] - 2024-07-09
 
@@ -19,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `-quiet` flag for NAG Fortran
 - Updated submodule for gFTL-shared (v1.9.0)
 - Update CI to remove `macos-12`, add `macos-14` and `ubuntu-24.04`, add `gfortran-14`
-
-### Added
-
-- LLVMFlang compiler support
 
 ## [1.7.0] - 2024-03-04
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- support for llvm flang
+
 ## [1.8.0] - 2024-07-09
 
 ### Changed

--- a/cmake/LLVMFlang.cmake
+++ b/cmake/LLVMFlang.cmake
@@ -1,0 +1,7 @@
+# Compiler specific flags for LLVM Flang
+
+set(cpp "-cpp")
+
+set(common_flags "${cpp}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")


### PR DESCRIPTION
This PR adds preliminary support for the `LLVMFlang` compiler. At the moment,
there are still issues with testing, etc.