### PR TITLE
Update gftl-shared; prepare for v1.10.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (FARGPARSE
-  VERSION 1.9.0
+  VERSION 1.10.0
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.10.0] - 2025-09-30
+
 ### Changed
 
+- Update submodule (gFTL-shared v1.11.0)
 - Update CMake minimum version to 3.24
 - Remove `macos-13` from CI, add `macos-15`
 - Add `gfortran-15` to macOS CI


### PR DESCRIPTION
This PR updates the gftl-shared submodule to v1.11.0 and prepares for a release here.